### PR TITLE
upgrade israli-bank-scrapers to 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "electron-updater": "^4.3.9",
     "emittery": "^0.7.1",
     "googleapis": "^59.0.0",
-    "israeli-bank-scrapers-core": "1.1.1",
+    "israeli-bank-scrapers-core": "1.2.0",
     "keytar": "^7.4.0",
     "lodash": "^4.17.15",
     "moment": "^2.24.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8433,10 +8433,10 @@ isobject@^3.0.0, isobject@^3.0.1:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
-israeli-bank-scrapers-core@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/israeli-bank-scrapers-core/-/israeli-bank-scrapers-core-1.1.1.tgz#8d108352b6f376b793031d913a678e79cbef1df6"
-  integrity sha512-EgciYDEWAWxIL9sus5hWnT8wjsWsAVetwbJJNJMYJ5GmjyoMYG/mM1guVKBi9P6MH/a2jQUDZxf1AL7/mork0w==
+israeli-bank-scrapers-core@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/israeli-bank-scrapers-core/-/israeli-bank-scrapers-core-1.2.0.tgz#d083709f2853b7a4f61f02563059100e7e136ff3"
+  integrity sha512-II0vLKzoq5u5NcuI4d3xuiTpdVpEALGrYxh/pKvIfGSCKcsE6MQg55WD4WzDgvcMhT2F4Lfa/MdpQevgsEkU9w==
   dependencies:
     build-url "^2.0.0"
     core-js "^3.1.4"


### PR DESCRIPTION
Package published automatically by Github Actions: https://github.com/eshaham/israeli-bank-scrapers/runs/2739732884

Diff: https://github.com/eshaham/israeli-bank-scrapers/compare/v1.1.1...v1.2.0