### PR TITLE
Add Chain Alert

### DIFF
--- a/.github/workflows/chainalert.yml
+++ b/.github/workflows/chainalert.yml
@@ -1,0 +1,13 @@
+name: "ChainAlert"
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  chainalert:
+    name: ChainAlert
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: checkmarx/chainalert-github-action@master


### PR DESCRIPTION
[ChainAlert](https://github.com/Checkmarx/chainalert-github-action) is a new product from Checkmarx to alert if we have a volnurability in the supply chain.﻿
