### PR TITLE
Add column(s) to Sheets exporter

### DIFF
--- a/src/backend/export/outputVendors/googleSheets/googleSheets.ts
+++ b/src/backend/export/outputVendors/googleSheets/googleSheets.ts
@@ -11,7 +11,7 @@ import { appendToSpreadsheet } from './googleSheetsInternalAPI';
 
 const GOOGLE_SHEETS_DATE_FORMAT = 'DD/MM/YYYY';
 const DEFAULT_SHEET_NAME = '_caspion';
-const COLUMN_HEADERS = ['תאריך', 'סכום', 'תיאור', 'תיאור נוסף', 'קטגוריה', 'מספר חשבון', 'hash - לא לגעת'];
+const COLUMN_HEADERS = ['תאריך', 'סכום', 'מטבע', 'תיאור', 'תיאור נוסף', 'קטגוריה', 'מספר חשבון', 'hash - לא לגעת'];
 
 const createTransactionsInGoogleSheets: ExportTransactionsFunction = async (
   { transactionsToCreate: transactions, outputVendorsConfig },
@@ -39,6 +39,7 @@ const createTransactionsInGoogleSheets: ExportTransactionsFunction = async (
   const transactionsInSheetsFormat = transactionsToCreate.map((transaction) => [
     moment(transaction.date).format(GOOGLE_SHEETS_DATE_FORMAT),
     transaction.chargedAmount,
+    transaction.originalCurrency,
     transaction.description,
     transaction.memo,
     transaction.category,


### PR DESCRIPTION
I'm opening this as a draft because I think it still needs thinking/work.

Background: I'm using Caspion with just Google Sheet as exported. Having no "Currency" field is a blocker for me as I can't differentiate when a new "USD" or alike transaction appears.

I've added the changed described in this PR, they do work, but the problem is **it's not backward compatible**.

(Note: The field "Currency" is discussed here, but once we agree on something I can add the rest of fields as appear in the bank scraper or CSV, if needed).

I see a few possible options to make it backward compatible:
1. "Quick and ugly": Instead of adding the field(s) columns in the middle, we can add those in the end (most right column). It's a bit ugly because they will appear after the "...hash..." column. Also, it doesn't promise it won't cause issues for users who are not expecting it. 
2. "Migrating date": Analyzing the structure of the current sheet and manipulating it to extend to new columns. Problem here is that also we're not sure if the sheet itself was manipulated. Also, this is a lot of work with introducing new features on the sheet itself.
3. "Only for new sheets": We can introduce the new fields only for new "sheeters" (🤣). Meaning, if we are creating the sheet for you now, we'll pour in the new fields. This is the most elegant solution IMO, but will require some leftovers in the codebase itself.
4. "Let the users shift the data manually" - we keep the code as it is now, and users will need to shift the code as they see right. meaning a breaking change, but easy to fix.

WDYT?

P.S. Thank you @brafdlog @baruchiro for this amazing code! much appreciated. 
