### PR TITLE
upgrade israeli-bank-scrapers

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "electron-updater": "^4.3.9",
     "emittery": "^0.10.0",
     "googleapis": "^87.0.0",
-    "israeli-bank-scrapers-core": "1.14.3",
+    "israeli-bank-scrapers-core": "2.0.0",
     "keytar": "^7.4.0",
     "lodash": "^4.17.15",
     "moment": "^2.29.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8460,10 +8460,10 @@ isobject@^3.0.0, isobject@^3.0.1:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
-israeli-bank-scrapers-core@1.14.3:
-  version "1.14.3"
-  resolved "https://registry.yarnpkg.com/israeli-bank-scrapers-core/-/israeli-bank-scrapers-core-1.14.3.tgz#0bba373ff87934d202c4d7ca6ca7faaa6c51c289"
-  integrity sha512-LVeBK7VlOREr6ORwfesbBYCwzHvtqzzoLf0E8xjLse3QgnO6OqtOdnVlKpHviWLjIcQ/iM193CN2X9dElJaKRg==
+israeli-bank-scrapers-core@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/israeli-bank-scrapers-core/-/israeli-bank-scrapers-core-2.0.0.tgz#269cf4bee546119e3f400a4d1d6f3b61899d7975"
+  integrity sha512-aPI1xXmutyyb9BlXVNZqe3FZf4/1iK29cYTUZSX8X0zJr+pYQzLQ2ydTLwo/+6HFZVU7iYqvydV3L+SArDB8ow==
   dependencies:
     build-url "^2.0.0"
     core-js "^3.1.4"
@@ -8472,6 +8472,7 @@ israeli-bank-scrapers-core@1.14.3:
     json2csv "^4.5.4"
     lodash "^4.17.10"
     moment "^2.22.2"
+    moment-timezone "^0.5.37"
     node-fetch "^2.2.0"
     puppeteer-core "^6.0.0"
     uuid "^3.3.2"
@@ -10424,6 +10425,18 @@ mkdirp@1.x, mkdirp@^1.0.3, mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
+
+moment-timezone@^0.5.37:
+  version "0.5.37"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.37.tgz#adf97f719c4e458fdb12e2b4e87b8bec9f4eef1e"
+  integrity sha512-uEDzDNFhfaywRl+vwXxffjjq1q0Vzr+fcQpQ1bU0kbzorfS7zVtZnCnGc8mhWmF39d4g4YriF6kwA75mJKE/Zg==
+  dependencies:
+    moment ">= 2.9.0"
+
+"moment@>= 2.9.0":
+  version "2.29.4"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
+  integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
 
 moment@^2.22.2, moment@^2.29.3:
   version "2.29.3"


### PR DESCRIPTION
https://github.com/eshaham/israeli-bank-scrapers/compare/v1.14.3...v2.0.0

# BREAKING CHANGES

- **[2.0.0](https://github.com/eshaham/israeli-bank-scrapers/compare/v1.15.1...v2.0.0) (2022-08-30):** changing default time-zone to Asia/Jerusalem shouldn't affect people scrapping usually from Israel but might affect people that always scrape outside of Israel.


## Features

- **[2.0.0](https://github.com/eshaham/israeli-bank-scrapers/compare/v1.15.1...v2.0.0) (2022-08-30):** use timezone Asia/Jerusalem by default (https://github.com/eshaham/israeli-bank-scrapers/issues/715) ([b369559](https://github.com/eshaham/israeli-bank-scrapers/commit/b369559c92c001cca9ce14c7ab75fde5629a895c))
- **[1.15.0](https://github.com/eshaham/israeli-bank-scrapers/compare/v1.14.4...v1.15.0) (2022-08-25):** add option to set the default timeout on puppeteer's page.setDefaultTimeout() (https://github.com/eshaham/israeli-bank-scrapers/issues/711) ([30061dd](https://github.com/eshaham/israeli-bank-scrapers/commit/30061dda9641d00f97a31b708ff46b4fe759b253))

## Bug Fixes

- **[1.15.1](https://github.com/eshaham/israeli-bank-scrapers/compare/v1.15.0...v1.15.1) (2022-08-30):** Mizrahi scraping issues when user does not need to update the email (https://github.com/eshaham/israeli-bank-scrapers/issues/710) ([f1f6a17](https://github.com/eshaham/israeli-bank-scrapers/commit/f1f6a178c03086b16e15d183024a7755599386fb))
- **[1.14.4](https://github.com/eshaham/israeli-bank-scrapers/compare/v1.14.3...v1.14.4) (2022-08-09):** card monthly fee throws an error (https://github.com/eshaham/israeli-bank-scrapers/issues/709) ([8c059f3](https://github.com/eshaham/israeli-bank-scrapers/commit/8c059f3f155ebc72c813188b8d0748f10f419107))