### PR TITLE
Keep the download URL consistent

### DIFF
--- a/nuxt/components/DownloadButton.vue
+++ b/nuxt/components/DownloadButton.vue
@@ -1,12 +1,12 @@
 <template>
   <div>
-    <button
+    <a
       :class="buttonStyle"
-      class="mx-auto lg:mx-0 hover:underline font-bold rounded-full py-4 px-8"
-      @click="download"
+      class="mx-auto lg:mx-0 hover:underline font-bold rounded-full py-4 px-8 block"
+      :href="mainLink"
     >
       התקן עכשיו
-    </button>
+    </a>
     <div
       v-if="showMoreDownloads"
       class="mx-auto text-center"
@@ -95,14 +95,19 @@ export default {
   },
   data() {
     return {
+      mainLink: '',
       downloads: [],
       os: 'Unknown',
       showDownloads: false,
-      releasesUrl: `https://github.com/${GITHUB_REPO}/releases`,
+      releasesUrl: `https://github.com/${GITHUB_REPO}/releases/latest`,
     };
   },
   created() {
     this.os = getOS();
+
+    this.mainLink = osToExtension[this.os]?.default
+      ? `${this.releasesUrl}/download/caspion.${osToExtension[this.os]?.default}`
+      : this.releasesUrl;
 
     axios
       .get(`https://api.github.com/repos/${GITHUB_REPO}/releases`)

--- a/nuxt/test/__snapshots__/HeroContent.spec.js.snap
+++ b/nuxt/test/__snapshots__/HeroContent.spec.js.snap
@@ -13,7 +13,7 @@ exports[`HeroContent renders properly 1`] = `
         בצורה מאובטחת, ללא צד שלישי ובפיקוח הקהילה
       </p>
       <div class=\\"mx-auto my-6\\">
-        <downloadbutton-stub showmoredownloads=\\"true\\" buttonstyle=\\"bg-white text-gray-800 shadow-lg\\"></downloadbutton-stub>
+        <downloadbutton-stub buttonstyle=\\"bg-white text-gray-800 shadow-lg\\"></downloadbutton-stub>
       </div>
     </div>
     <div class=\\"w-full md:w-3/5 py-6 md:pr-2 text-center\\"><img src=\\"~/assets/img/main-screenshot.png\\" alt=\\"\\" class=\\"w-full \\"></div>

--- a/vue.config.js
+++ b/vue.config.js
@@ -35,6 +35,8 @@ module.exports = {
             releaseType: 'release'
           }
         ],
+        // eslint-disable-next-line no-template-curly-in-string
+        artifactName: '${productName}.${ext}',
         dmg: {
           contents: [
             {


### PR DESCRIPTION
- remove version from artifact name: We need the downloaded file from a release to be in a constant name (currently it includes the version)
- keep the same download link with 'latest'
- remove "more downloads" button

We will have to check the artifact filenames because they have different format for each file type.

This PR will not trigger a relase.
