### PR TITLE
Fix: Ensure consistent dates for G-Sheets export

### DIFF
--- a/src/backend/export/outputVendors/googleSheets/googleSheets.ts
+++ b/src/backend/export/outputVendors/googleSheets/googleSheets.ts
@@ -9,7 +9,7 @@ import { createClient } from './googleAuth';
 import * as googleSheets from './googleSheetsInternalAPI';
 import { appendToSpreadsheet } from './googleSheetsInternalAPI';
 
-const GOOGLE_SHEETS_DATE_FORMAT = 'DD/MM/YYYY';
+const GOOGLE_SHEETS_DATE_FORMAT = 'YYYY-MM-DD';
 const DEFAULT_SHEET_NAME = '_caspion';
 const COLUMN_HEADERS = [
   'תאריך',


### PR DESCRIPTION
This is a fix for https://github.com/brafdlog/caspion/issues/476 ("google spreadsheet dates inconsistent cell format")

The fix is to  use the format of `YYYY-MM-DD` which has no ambiguity and Google Sheets will automatically detect it as a date field.

I did not see any unit-testing in this project so added no tests. If I am missing the tests, I will add.