### PR TITLE
Build: Add stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,5 +9,6 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
+          days-before-close: 14
           stale-issue-message: 'Issue has been marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.'
           stale-pr-message: 'Pull request has been marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,13 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: 'Issue has been marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.'
+          stale-pr-message: 'Pull request has been marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.'


### PR DESCRIPTION
The configuration must be on the default branch and the values will:

1. Add a label "Stale" on issues and pull requests after 60 days of inactivity and comment on them
2. Close the stale issues and pull requests after 14 days of inactivity
3. If an update/comment occur on stale issues or pull requests, the stale label will be removed and the timer will restart