### PR TITLE
Fix: Added import id for YNAB

### DIFF
--- a/packages/main/src/backend/export/outputVendors/ynab/ynab.test.ts
+++ b/packages/main/src/backend/export/outputVendors/ynab/ynab.test.ts
@@ -6,9 +6,9 @@ import * as ynab from './ynab';
 import ClearedEnum = SaveTransaction.ClearedEnum;
 
 describe('ynab', () => {
-  describe('isSameTransaction(Payee changed)', () => {
+  describe('isSameTransaction', () => {
     test('Two transactions with different payee names should be considered the same if they have the same import id', () => {
-      const transferTransactionFromYnab: TransactionDetail = {
+      const differentPayeeTransactionFromYnab: TransactionDetail = {
         id: '579ae642-d161-4bbe-9d54-ae3322c93cf7',
         date: '2019-06-27',
         amount: -1000000,
@@ -39,10 +39,8 @@ describe('ynab', () => {
         import_id: '2019-06-27-1000000שיק',
       };
 
-      expect(ynab.isSameTransaction(transactionFromFinancialAccount, transferTransactionFromYnab)).toBeTruthy();
+      expect(ynab.isSameTransaction(transactionFromFinancialAccount, differentPayeeTransactionFromYnab)).toBeTruthy();
     });
-  });
-  describe('isSameTransaction', () => {
     test('Two transactions with different payee names should be considered the same if one of them is a transfer transaction', () => {
       const transferTransactionFromYnab: TransactionDetail = {
         id: '579ae642-d161-4bbe-9d54-ae3322c93cf7',

--- a/packages/main/src/backend/export/outputVendors/ynab/ynab.test.ts
+++ b/packages/main/src/backend/export/outputVendors/ynab/ynab.test.ts
@@ -25,7 +25,7 @@ describe('ynab', () => {
         transfer_account_id: null,
         transfer_transaction_id: null,
         matched_transaction_id: null,
-        import_id: '2019-06-27-1000000',
+        import_id: '2019-06-27-1000000שיק',
         deleted: false,
         subtransactions: [],
       };
@@ -36,7 +36,7 @@ describe('ynab', () => {
         payee_name: 'גן',
         category_id: '4e0ttc69-b4f6-420b-8d07-986c8225a3d4',
         cleared: ClearedEnum.Cleared,
-        import_id: '2019-06-27-1000000',
+        import_id: '2019-06-27-1000000שיק',
       };
 
       expect(ynab.isSameTransaction(transactionFromFinancialAccount, transferTransactionFromYnab)).toBeTruthy();

--- a/packages/main/src/backend/export/outputVendors/ynab/ynab.test.ts
+++ b/packages/main/src/backend/export/outputVendors/ynab/ynab.test.ts
@@ -6,6 +6,42 @@ import * as ynab from './ynab';
 import ClearedEnum = SaveTransaction.ClearedEnum;
 
 describe('ynab', () => {
+  describe('isSameTransaction(Payee changed)', () => {
+    test('Two transactions with different payee names should be considered the same if they have the same import id', () => {
+      const transferTransactionFromYnab: TransactionDetail = {
+        id: '579ae642-d161-4bbe-9d54-ae3322c93cf7',
+        date: '2019-06-27',
+        amount: -1000000,
+        memo: null,
+        cleared: SaveTransaction.ClearedEnum.Cleared,
+        approved: true,
+        flag_color: null,
+        account_id: 'SOME_ACCOUNT_ID',
+        account_name: 'My great account',
+        payee_id: 'fd7f187c-0633-434f-aaxe-1fevd68492cb',
+        payee_name: 'שיק',
+        category_id: null,
+        category_name: null,
+        transfer_account_id: null,
+        transfer_transaction_id: null,
+        matched_transaction_id: null,
+        import_id: '2019-06-27-1000000',
+        deleted: false,
+        subtransactions: [],
+      };
+      const transactionFromFinancialAccount: SaveTransaction = {
+        account_id: 'SOME_ACCOUNT_ID',
+        date: '2019-06-27',
+        amount: -1000000,
+        payee_name: 'גן',
+        category_id: '4e0ttc69-b4f6-420b-8d07-986c8225a3d4',
+        cleared: ClearedEnum.Cleared,
+        import_id: '2019-06-27-1000000',
+      };
+
+      expect(ynab.isSameTransaction(transactionFromFinancialAccount, transferTransactionFromYnab)).toBeTruthy();
+    });
+  });
   describe('isSameTransaction', () => {
     test('Two transactions with different payee names should be considered the same if one of them is a transfer transaction', () => {
       const transferTransactionFromYnab: TransactionDetail = {

--- a/packages/main/src/backend/export/outputVendors/ynab/ynab.ts
+++ b/packages/main/src/backend/export/outputVendors/ynab/ynab.ts
@@ -197,6 +197,7 @@ export function isSameTransaction(
   transactionFromYnab: ynab.TransactionDetail,
 ) {
   const isATransferTransaction = !!transactionFromYnab.transfer_account_id;
+  const isTransactionsImportIdEqual = isSameImportId(transactionToCreate, transactionFromYnab);
   return (
     transactionToCreate.account_id === transactionFromYnab.account_id &&
     transactionToCreate.date === transactionFromYnab.date &&
@@ -205,7 +206,7 @@ export function isSameTransaction(
     // In a transfer transaction the payee name changes, but we still consider this the same transaction
     (areStringsEqualIgnoreCaseAndWhitespace(transactionToCreate.payee_name, transactionFromYnab.payee_name) ||
       isATransferTransaction ||
-      isSameImportId(transactionToCreate, transactionFromYnab))
+      isTransactionsImportIdEqual)
   );
 }
 

--- a/packages/main/src/backend/export/outputVendors/ynab/ynab.ts
+++ b/packages/main/src/backend/export/outputVendors/ynab/ynab.ts
@@ -16,6 +16,7 @@ import * as ynab from 'ynab';
 const YNAB_DATE_FORMAT = 'YYYY-MM-DD';
 const NOW = moment();
 const MIN_YNAB_ACCESS_TOKEN_LENGTH = 43;
+const MAX_YNAB_IMPORT_ID_LENGTH = 36;
 
 const categoriesMap = new Map<string, Pick<ynab.Category, 'id' | 'name' | 'category_group_id'>>();
 const transactionsFromYnab = new Map<Date, ynab.TransactionDetail[]>();
@@ -118,7 +119,7 @@ function convertTransactionToYnabFormat(originalTransaction: EnrichedTransaction
     category_id: getYnabCategoryIdFromCategoryName(originalTransaction.category),
     memo: originalTransaction.memo,
     cleared: ynab.SaveTransaction.ClearedEnum.Cleared,
-    import_id: buildImportId(originalTransaction),
+    import_id: buildImportId(originalTransaction), // [date][amount][description]
     // "approved": true,
     // "flag_color": "red",
     // "import_id": buildImportId(originalTransaction.description, amount, date) // 'YNAB:[milliunit_amount]:[iso_date]:[occurrence]'
@@ -126,7 +127,10 @@ function convertTransactionToYnabFormat(originalTransaction: EnrichedTransaction
 }
 
 function buildImportId(transaction: EnrichedTransaction): string {
-  return `${transaction.date.substring(0, 10)}${transaction.chargedAmount}${transaction.description}`.substring(0, 36);
+  return `${transaction.date.substring(0, 10)}${transaction.chargedAmount}${transaction.description}`.substring(
+    0,
+    MAX_YNAB_IMPORT_ID_LENGTH,
+  );
 }
 
 function getYnabAccountIdByAccountNumberFromTransaction(transactionAccountNumber: string): string {


### PR DESCRIPTION
In order to avoid duplicate inserted when a payee is changed, an import_id is added to the YNAB transaction

Fix #625 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced transaction handling with the introduction of a new property for import IDs.
	- Added a new function to generate import IDs based on transaction details.
	- Introduced a function to compare transactions based on their import IDs.

- **Bug Fixes**
	- Improved error handling in transaction creation to notify users when no transactions exist.

- **Tests**
	- Added a new test case for the `isSameTransaction` function to verify behavior with different payees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->