### PR TITLE
Build: fix linux build

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          # - windows-latest
+          - windows-latest
           - ubuntu-latest
           # - macos-latest
 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -9,6 +9,7 @@ files:
 
 linux:
   target: deb
+  icon: packages/renderer/src/assets/logos/logoFishOnly.png
 
 publish:
   - provider: github


### PR DESCRIPTION
Fixes #640: Linux build was failing due to icon. It doesn't seem to work with `ics` or `ico` formats, or at least not the ones which are used for Mac/Windows.
To mitigate, set a png icon.

Note that for some reason the icon does not seem to actually apply:
![image](https://github.com/user-attachments/assets/8be0db2d-8459-47fe-a712-e5db72761635)
I thought it might be due to the png dimensions, but I tried setting a 512x512 png instead and the result was the same. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the Linux application build with a fresh icon for enhanced visual branding.
- **Improvements**
	- Expanded the testing matrix to include Windows as an operating system for running tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->