### PR TITLE
Fix: Ubuntu GitHub test action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
+      - name: Setup Ubuntu Binary Installation # TODO: Remove when https://github.com/electron/electron/issues/42510 is fixed
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          if grep -q "Ubuntu 24" /etc/os-release; then
+            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          fi
+        shell: bash
       - uses: actions/setup-node@v4
         with:
           cache: 'yarn'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
       # I ran into problems trying to run an electron window in ubuntu due to a missing graphics server.
       # That's why this special command for Ubuntu is here
       - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- yarn test:e2e
-        if: matrix.os == 'ubuntu-22.04'
+        if: startsWith(matrix.os, 'ubuntu')
 
       - run: yarn test:e2e
-        if: matrix.os != 'ubuntu-22.04'
+        if: ${{ !startsWith(matrix.os, 'ubuntu') }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,19 +18,12 @@ jobs:
       matrix:
         os:
           # - windows-latest
-          - ubuntu-latest
+          - ubuntu-22.04 # TODO: Use latest when https://github.com/electron/electron/issues/42510 is fixed
           # - macos-latest
 
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
-      - name: Setup Ubuntu Binary Installation # TODO: Remove when https://github.com/electron/electron/issues/42510 is fixed
-        if: ${{ runner.os == 'Linux' }}
-        run: |
-          if grep -q "Ubuntu 24" /etc/os-release; then
-            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
-          fi
-        shell: bash
       - uses: actions/setup-node@v4
         with:
           cache: 'yarn'
@@ -45,7 +38,7 @@ jobs:
       # I ran into problems trying to run an electron window in ubuntu due to a missing graphics server.
       # That's why this special command for Ubuntu is here
       - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- yarn test:e2e
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-22.04'
 
       - run: yarn test:e2e
-        if: matrix.os != 'ubuntu-latest'
+        if: matrix.os != 'ubuntu-22.04'


### PR DESCRIPTION
The `ubuntu-latest` tag was changed to point to Ubuntu 24.04 and has caused regressions. See https://github.com/microsoft/playwright/issues/34251 and https://github.com/electron/electron/issues/42510 for more details.
TL;DR: 
> The solution is to lift the restrictions that Ubuntu 24.04 implements in the AppImages.
> ```
> sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
> ```

## Update
The command above fixed the `Process failed to launch` error, but instead produced a `Timeout 30000ms exceeded` error. For now, setting tests to run on ubuntu-22.04 as that seems to work at the moment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
	- Enhanced the automated testing workflow by updating the operating system to Ubuntu 22.04, improving the reliability of our testing process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->