### PR TITLE
New: Skip YNAB export for unmapped accounts

### DIFF
--- a/packages/main/src/backend/commonTypes.ts
+++ b/packages/main/src/backend/commonTypes.ts
@@ -100,6 +100,15 @@ export type ExportTransactionsFunction = (
   eventPublisher: EventPublisher,
 ) => Promise<ExportTransactionsResult>;
 
+export interface ExportTransactionsForAccountParams extends ExportTransactionsParams {
+  accountNumber: string;
+}
+
+export type ExportTransactionsForAccountFunction = (
+  exportTransactionsParams: ExportTransactionsForAccountParams,
+  eventPublisher: EventPublisher,
+) => Promise<ExportTransactionsResult>;
+
 export interface OutputVendor {
   name: OutputVendorName;
   init?: (outputVendorsConfig: Config['outputVendors']) => Promise<void>;


### PR DESCRIPTION
1. Refactored YNAB exporter to run per account
2. If account is not mapped, skip it instead of throwing

Closes #644. Please read the issue for more details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added account-specific transaction export capabilities, allowing users to filter and export transactions by account number.
  - Enhanced transaction processing with integrated vendor configuration and improved error notifications to better inform users when accounts are unmapped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->