### PR TITLE
Docs: Replace broken command with `yarn watch`

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ For M1 macs, if you get an error while scraping due to not being able to downloa
 ### Start from Source
 
 - Run `yarn` to install the dependencies
-- Run `yarn serve` to start the app
+- Run `yarn watch` to start the app
 - Set up additional exporters (Optional)
   - If you want to set up YNAB or Google Sheets, see instructions below
 - Run by clicking on the `Run` button in the app


### PR DESCRIPTION
The setup instructions say to use `yarn serve`. Doing so results in the following error:

```
yarn run v1.22.22
error Command "serve" not found.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

Instead of using `yarn serve`, the command `yarn watch` can be used as suggested previously on Discord.

![image](https://github.com/user-attachments/assets/b23f7a8d-4084-4a99-bd82-c440dcdabc53)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the instructions for starting the application to use "yarn watch" instead of "yarn serve", ensuring the user guide aligns with the current development process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->